### PR TITLE
Enable post querying for large parameter sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9.7.0] - 2021-02-27
+### Changed
+* runInstalledQuery(usePost=True) will post params as body 
+
 ## [0.0.9.6.3] - 2020-12-14
 ### Fixed
 * Fixed (more) runInstalledQuery() params 

--- a/pyTigerGraph/__init__.py
+++ b/pyTigerGraph/__init__.py
@@ -1,4 +1,4 @@
 from pyTigerGraph.pyTigerGraph import TigerGraphConnection
 
-__version__ = "0.0.9.6.3"
+__version__ = "0.0.9.7.0"
 __license__ = "MIT"

--- a/pyTigerGraph/pyTigerGraph.py
+++ b/pyTigerGraph/pyTigerGraph.py
@@ -1259,7 +1259,7 @@ class TigerGraphConnection(object):
             return pd.DataFrame(ret).T
         return ret
 
-    def runInstalledQuery(self, queryName, params=None, timeout=None, sizeLimit=None):
+    def runInstalledQuery(self, queryName, params=None, timeout=None, sizeLimit=None, usePost=False):
         """Runs an installed query.
 
         The query must be already created and installed in the graph.
@@ -1271,6 +1271,9 @@ class TigerGraphConnection(object):
                        See https://docs.tigergraph.com/dev/restpp-api/restpp-requests#gsql-query-timeout
         - `sizeLimit`: Maximum size of response (in bytes).
                        See https://docs.tigergraph.com/dev/restpp-api/restpp-requests#request-body-size
+        - `usePost`:   RestPP accepts a maximum URL length of 8192 characters. Use POST if params cause you to
+                       exceed this limit.
+                       See https://docs.tigergraph.com/dev/gsql-ref/querying/query-operations#running-a-query-as-a-rest-endpoint
 
         Endpoint:      POST /query/{graph_name}/<query_name>
         Documentation: https://docs.tigergraph.com/dev/gsql-ref/querying/query-operations#running-a-query
@@ -1282,8 +1285,9 @@ class TigerGraphConnection(object):
             headers["RESPONSE-LIMIT"] = str(sizeLimit)
         if isinstance(params, dict):
             params = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
-            return self._get(self.restppUrl + "/query/" + self.graphname + "/" + queryName, params=params, headers=headers)
 
+        if usePost:
+            return self._post(self.restppUrl + "/query/" + self.graphname + "/" + queryName, data=params, headers=headers)
         else:
             return self._get(self.restppUrl + "/query/" + self.graphname + "/" + queryName, params=params, headers=headers)
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", encoding='utf-8') as fh:
 setup(
   name = 'pyTigerGraph',         # How you named your package folder (MyLib)
   packages = ['pyTigerGraph'],   # Chose the same as "name"
-  version = '0.0.9.6.3',      # Start with a small number and increase it with every change you make
+  version = '0.0.9.7.0',      # Start with a small number and increase it with every change you make
   license='MIT',        # Chose a license from here: https://help.github.com/articles/licensing-a-repository
   description = 'Library to connect to TigerGraph databases',   # Give a short description about your library
   long_description=long_description,


### PR DESCRIPTION
I didn't see a `CONTRIBUTING.md` so please forgive me if I've violated any guidelines.

I've been running into Tigergraph's 8192 character url length limit when using `TigerGraphConnection.runInstalledQuery()`, so I've proposed an additional parameter (`usePost: bool`) to runInstalledQuery, in order to switch to using POST instead of GET.

I would prefer to change the function to always use POST, as that should be a non-breaking change. However, I have no idea what other people's configurations are. https://xkcd.com/1172/