### PR TITLE
SSL Cert Port Configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9.6.9] - 2021-06-03
+### Changed
+* Made SSL Port configurable to grab SSL cert from different port in case of firewall on 443
+
 ## [0.0.9.6.3] - 2020-12-14
 ### Fixed
 * Fixed (more) runInstalledQuery() params 

--- a/pyTigerGraph/__init__.py
+++ b/pyTigerGraph/__init__.py
@@ -1,4 +1,4 @@
 from pyTigerGraph.pyTigerGraph import TigerGraphConnection
 
-__version__ = "0.0.9.6.8"
+__version__ = "0.0.9.6.9"
 __license__ = "MIT"

--- a/pyTigerGraph/pyTigerGraph.py
+++ b/pyTigerGraph/pyTigerGraph.py
@@ -64,6 +64,7 @@ class TigerGraphConnection(object):
                                Developer.
                                When True the certificate would be downloaded when it is first needed.
                                on the first GSQL command.
+        - `sslPort`:           Configurable port for ssl cert fetching in case of firewall on 443. Will use 14240.
         """
         inputHost = urlparse(host)
         # if inputHost.port not in [gsPort,restppPort,"80","443"] :

--- a/pyTigerGraph/pyTigerGraph.py
+++ b/pyTigerGraph/pyTigerGraph.py
@@ -47,7 +47,7 @@ class TigerGraphConnection(object):
     def __init__(self, host="http://127.0.0.1", graphname="MyGraph", username="tigergraph", password="tigergraph",
                  restppPort="9000", gsPort="14240", gsqlVersion="", version="", apiToken="", useCert=True,
                  certPath=None,
-                 debug=False):
+                 debug=False, sslPort="443"):
         """Initiate a connection object.
 
         Arguments
@@ -105,6 +105,7 @@ class TigerGraphConnection(object):
             self.useCert = True
             self.certPath = certPath
         self.downloadJar = False
+        self.sslPort = sslPort
 
         self.gsqlInitiated = False
 
@@ -1538,7 +1539,7 @@ https://docs.tigergraph.com/dev/gsql-ref/querying/declaration-and-assignment-sta
         sslhost = self.url.split(":")[0]
         if self.downloadCert:  # HTTP/HTTPS
             import ssl
-            Res = ssl.get_server_certificate((sslhost, 443))
+            Res = ssl.get_server_certificate((sslhost, self.sslPort))
             # print(Res)
             try:
                 certcontent = open(self.certLocation, 'w')

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", encoding='utf-8') as fh:
 setup(
   name = 'pyTigerGraph',         # How you named your package folder (MyLib)
   packages = ['pyTigerGraph'],   # Chose the same as "name"
-  version = '0.0.9.6.8',      # Start with a small number and increase it with every change you make
+  version = '0.0.9.6.9',      # Start with a small number and increase it with every change you make
   license='MIT',        # Chose a license from here: https://help.github.com/articles/licensing-a-repository
   description = 'Library to connect to TigerGraph databases',   # Give a short description about your library
   long_description=long_description,


### PR DESCRIPTION
Make Port Configurable in case of firewall on port 443 used to fetch SSL cert.
GsPort 14240 works in the case of 443 having firewall.