### PR TITLE
Fix exit call and change exit code

### DIFF
--- a/pyTigerGraph/pyTigerGraph.py
+++ b/pyTigerGraph/pyTigerGraph.py
@@ -1722,7 +1722,7 @@ https://docs.tigergraph.com/dev/gsql-ref/querying/declaration-and-assignment-sta
                     return res
         else:
             print("Couldn't Initialize the client see Above Error")
-            exit(0)
+            sys.exit(1)
 
         return
 


### PR DESCRIPTION
This one-line change brings two changes:
- It changes the exit code from 0 to 1. The exit is called after an error, I assume it would be more suitable to return non-zero exit code. (`0` means a normal exit, but from the print it is obvious it is not a normal exit)
- It uses `sys.exit` rather than just `exit`. `exit` belongs to the built-in constants - quoting from [Python docs](https://docs.python.org/3/library/constants.html#exit): `They are useful for the interactive interpreter shell and should not be used in programs.`. Even though the functionality is the same, in certain setup `exit` constant can lead to errors: 

```bash
NameError: name 'exit' is not defined
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
File <[command-4077477496465786]()>:7, in <module>
      3 import pyTigerGraph as tg
      5 conn = tg.TigerGraphConnection(host=host_ip, graphname=name)
----> 7 print(conn.gsql('ls',options =[]))

File .../site-packages/pyTigerGraph/pyTigerGraph.py:1725, in TigerGraphConnection.gsql(self, query, graphname, options)
   1723 else:
   1724     print("Couldn't Initialize the client see Above Error")
-> 1725     exit(0)
   1727 return
```